### PR TITLE
Adding reference to fix build issue on a Mac.

### DIFF
--- a/LogicUnitTests/HomeAutomationAppTests.csproj
+++ b/LogicUnitTests/HomeAutomationAppTests.csproj
@@ -35,6 +35,7 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />


### PR DESCRIPTION
This fixes the following build error on the master branch using Xamarin on a Mac:

```
/Users/jpz/src/Automation_System/MobileApp/LogicUnitTests/Test.cs(40,40): Error CS0012: The type `System.Net.Http.HttpResponseMessage' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' (CS0012) (HomeAutomationAppTests)
```
