### PR TITLE
Adding reference to TimeFrame, so it can be used.

### DIFF
--- a/HomeAutomationApp/HomeAutomationApp.csproj
+++ b/HomeAutomationApp/HomeAutomationApp.csproj
@@ -209,5 +209,9 @@
       <Project>{DCE2FD21-5B48-4413-A2A2-B55D1B70C7D4}</Project>
       <Name>api</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\sim_harness\time_frame\time_frame\time_frame.csproj">
+      <Project>{E9C8A0A8-16D9-4FEF-AB45-04E9EE9A579E}</Project>
+      <Name>time_frame</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Sim Harness team wrote a TimeFrame class to encapsulate the ability to generate timestamps across the project in simulated configurations, which is used extensively throughout the project. When integrating the DeviceAPI, it was discovered that the MobileApp is not using the library - instead, that functionality was re-implemented from scratch. This creates issues when trying to build the system, since references are not being used to common elements.

This PR does the minimum amount of effort to integrate the two, which is adding the time_frame library as a reference so other parts of the system build. Unfortunately, this means there is a decent chunk of refactoring/hacking that needs to be done to bridge the two implementations so objects can be passed between the MobileApp and DeviceAPI.
